### PR TITLE
Fix "Welcome, <b>{{name}}</b>!" in site builders guide

### DIFF
--- a/pages/site-builders.markdown
+++ b/pages/site-builders.markdown
@@ -42,7 +42,7 @@ When you need to express something that isn’t expressible in markdown, it’s 
 
 A template is a file written in an extension of HTML that includes commands that generate HTML from the values of certain variables in scope. Templates are used by web frameworks for generating the pages that are returned by web requests; you can think of a template as a function from an environment (a collection of bindings of variables) to an HTML page. For example, a template might include the text
 
-	Welcome, <b>{{name}}</b>!
+	Welcome, <b>{{"{{"}}name}}</b>!
 
 This includes some standard HTML (eg, the bold tag) but also some special templating text, which is demarcated by the curly braces. Roughly speaking, templating text is treated as an expression to be evaluated. So in this case, the web app has presumably assigned to the variable *name* the string representing the user’s name.
 


### PR DESCRIPTION
hello! i'm taking this course this semester and was reading the "What I wish I’d known about website builders" page when i noticed that the example template didn't seem to contain the "special templating text" or curly braces mentioned in the prose.

<img width="643" alt="image" src="https://user-images.githubusercontent.com/4264038/188533363-5fd30e1b-8b86-4893-91a9-7ebc9120fb14.png">

it seems that the Liquid filter is actually being evaluated. i think i found a reasonable way to achieve the desired output (after trying and failing with several more-obvious approaches, like `\{\{` and `\{{`; using the html escape sequence `&#123;` doesn't work in the markdown code block), so i wanted to suggest a fix. thanks!