### PR TITLE
Add new page for recitations and studio hours

### DIFF
--- a/recitation-and-studio.md
+++ b/recitation-and-studio.md
@@ -1,0 +1,35 @@
+---
+title: Recitations and Studio Hours
+layout: page
+---
+
+## Recitation Schedule
+
+Note: We will only be using one room per section despite what may be on the registrar.
+
+Each section’s room will most likely not change, but TAs will be updated based on recitation week + topic.
+
+Recitations are not assigned, and you can attend the section that works best for you.
+
+| Recitation Time | Location | TA (for 9/8)                    |
+| --------------- | -------- | ------------------------------- |
+| R10 (10am-11am) | 38-166   | Annie Zhang (annzhang@mit.edu)  |
+| R11 (11am-12pm) | 34-301   | Annie Zhang (annzhang@mit.edu)  |
+| R12 (12pm-1pm)  | 34-301   | Annie Zhang (annzhang@mit.edu)  |
+| R1 (1pm-2pm)    | 34-303   | Jaeyoon Song (jaeyoons@mit.edu) |
+| R2 (2pm-3pm)    | 34-301   | Jaeyoon Song (jaeyoons@mit.edu) |
+| R3 (3pm-4pm)    | 34-301   | Jaeyoon Song (jaeyoons@mit.edu) |
+
+## Studio Hours Schedule
+
+This is the schedule for the first week of classes (Wed 9/7 to Tue 9/13 inclusive). Subject to change after the first week!
+
+Location: Stata G tower 7th floor common area (right in front of the elevators)
+
+| Sun | 1-2pm | Zachary Deng|
+| Mon | 4-5pm| Shuli Jones |
+| Tue | 4-5pm | Annie Zhang |
+| Wed | none | |
+| Thu | 6-7pm, 7-8pm | Kathryn Jin, Mufaro Makiwa |
+| Fri | 3-4pm | Jaeyoon Song |
+| Sat | 4-5pm | Kailey Yang |


### PR DESCRIPTION
Replicating the schedule for recitations and studio hours seen on canvas https://canvas.mit.edu/courses/16626/pages/recitation-and-studio-hours-schedule?module_item_id=688319

<img width="858" alt="CleanShot 2022-09-07 at 14 10 06@2x" src="https://user-images.githubusercontent.com/43298927/188948781-122c53bc-35c1-4866-9e6d-8a0df8ade166.png">
